### PR TITLE
Change tf.Session to grow dynamically

### DIFF
--- a/foolbox_model.py
+++ b/foolbox_model.py
@@ -31,8 +31,13 @@ def create():
     with TowerContext(tower_name='', is_training=False):
         logits = model.get_logits(image)
 
-    with tf.Session() as session:
-         model = get_model_loader(weights_path).init(sess)
-    
-    fmodel = TensorFlowModel(image, logits, channel_axis=1, bounds=[0, 255.], preprocessing=(127.5, 127.5))
+    config = tf.ConfigProto()
+    config.gpu_options.allow_growth=True
+    session = tf.Session(config=config)
+    with session.as_default():
+         model = get_model_loader(weights_path).init(session)
+            
+         fmodel = TensorFlowModel(image, logits, channel_axis=1, bounds=[0, 255.], preprocessing=(127.5, 127.5))
+
     return fmodel
+


### PR DESCRIPTION
The TensorFlow session now does not reserve the whole memory of the GPU but grows dynamically. This allows one to load multiple networks (e.g. PyTorch models) at the same time.